### PR TITLE
Fix preference for packages from default channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 .scannerwork/
 coverage_report*.xml
 .coverage*
+

--- a/scripts/zwik_client.py
+++ b/scripts/zwik_client.py
@@ -191,14 +191,17 @@ class ZwikSettings:
             log.exception("Error while running settings hook")
         return False
 
-    def resolve_channel(self, channel, label=None):
+    def resolve_channel(self, channel, label=None, with_credentials=True):
         from urllib.parse import quote, urlparse
 
         if label:
             channel += "/labels/" + label
         if not urlparse(channel).scheme:
             channel = self.channel_alias.rstrip("/") + "/" + channel
-        credential = self.credentials.obtain(channel + "/noarch/repodata.json")
+        if with_credentials:
+            credential = self.credentials.obtain(channel + "/noarch/repodata.json")
+        else:
+            credential = None
         if credential:
             parsed_url = urlparse(channel)
             hostname = parsed_url.hostname
@@ -214,7 +217,7 @@ class ZwikSettings:
             ).geturl()
         return channel
 
-    def resolve_channels(self, channels=(), labels=("",)):
+    def resolve_channels(self, channels=(), labels=("",), with_credentials=True):
         expanded_channels = []
         append_default_channels = True
         for channel in channels:
@@ -234,7 +237,11 @@ class ZwikSettings:
         for label in labels:
             for channel in expanded_channels:
                 try:
-                    resolved_channels.append(self.resolve_channel(channel, label))
+                    resolved_channels.append(
+                        self.resolve_channel(
+                            channel, label, with_credentials=with_credentials
+                        )
+                    )
                 except UrlNotFoundError:
                     pass
         return resolved_channels
@@ -1179,10 +1186,11 @@ class ZwikEnvironment(object):
     def _multiple_packages_found(result) -> bool:
         return len(set([x.md5 for x in result])) > 1
 
-    @staticmethod
-    def _filter_package_from_default_channels(result, default_channels, spec):
-        default_channel_names = [c.rsplit("/", 1)[-1] for c in default_channels]
-        from_defaults = [x for x in result if x.schannel in default_channel_names]
+    def _filter_package_from_default_channels(self, result, spec):
+        default_channels = self.settings.resolve_channels(
+            ["defaults"], with_credentials=False
+        )
+        from_defaults = [x for x in result if x.channel.base_url in default_channels]
         if len(from_defaults) == 1:
             log.warning("Force using %s from default channel", spec)
             result = from_defaults
@@ -1204,9 +1212,6 @@ class ZwikEnvironment(object):
         )
         obsolete_channels = self.settings.resolve_channels(
             self.lock_data["channels"], ("obsolete",)
-        )
-        default_channels = self.settings.resolve_channels(
-            ["defaults"],
         )
         subdirs = [self.lock_data["subdir"], "noarch"]
         link_precs = []
@@ -1231,9 +1236,7 @@ class ZwikEnvironment(object):
                 else:
                     raise AssertionError("Package not found: {}".format(spec))
             if self._multiple_packages_found(result):
-                result = self._filter_package_from_default_channels(
-                    result, default_channels, spec
-                )
+                result = self._filter_package_from_default_channels(result, spec)
             link_precs.append(result[0])
 
         additional_args = []

--- a/scripts/zwik_client.py
+++ b/scripts/zwik_client.py
@@ -1187,12 +1187,12 @@ class ZwikEnvironment(object):
 
     @staticmethod
     def _multiple_packages_found(result) -> bool:
-        return len(set([x.md5 for x in result])) > 1
+        return len({x.md5 for x in result}) > 1
 
     def _filter_package_from_default_channels(self, result, spec):
         if self._default_channel_urls is None:
-            self._default_channel_urls = self.settings.resolve_channels(
-                ["defaults"], with_credentials=False
+            self._default_channel_urls = set(
+                self.settings.resolve_channels(["defaults"], with_credentials=False)
             )
         from_defaults = [
             x for x in result if x.channel.base_url in self._default_channel_urls

--- a/scripts/zwik_client.py
+++ b/scripts/zwik_client.py
@@ -706,6 +706,7 @@ class ZwikEnvironment(object):
         self.yaml_path = None
         self.lockfile_hash = None
         self._installation_checked = False
+        self._default_channel_urls = None
 
     @classmethod
     def from_yaml(cls, zwik_settings, yaml_file, working_dir=None):
@@ -1187,10 +1188,13 @@ class ZwikEnvironment(object):
         return len(set([x.md5 for x in result])) > 1
 
     def _filter_package_from_default_channels(self, result, spec):
-        default_channels = self.settings.resolve_channels(
-            ["defaults"], with_credentials=False
-        )
-        from_defaults = [x for x in result if x.channel.base_url in default_channels]
+        if self._default_channel_urls is None:
+            self._default_channel_urls = self.settings.resolve_channels(
+                ["defaults"], with_credentials=False
+            )
+        from_defaults = [
+            x for x in result if x.channel.base_url in self._default_channel_urls
+        ]
         if len(from_defaults) == 1:
             log.warning("Force using %s from default channel", spec)
             result = from_defaults

--- a/scripts/zwik_client.py
+++ b/scripts/zwik_client.py
@@ -239,7 +239,9 @@ class ZwikSettings:
                 try:
                     resolved_channels.append(
                         self.resolve_channel(
-                            channel, label, with_credentials=with_credentials
+                            channel=channel,
+                            label=label,
+                            with_credentials=with_credentials,
                         )
                     )
                 except UrlNotFoundError:

--- a/scripts/zwik_client.py
+++ b/scripts/zwik_client.py
@@ -1197,11 +1197,15 @@ class ZwikEnvironment(object):
         from_defaults = [
             x for x in result if x.channel.base_url in self._default_channel_urls
         ]
-        if len(from_defaults) == 1:
+        number_of_defaults = len(from_defaults)
+        if number_of_defaults == 1:
             log.warning("Force using %s from default channel", spec)
             result = from_defaults
         else:
-            raise AssertionError("Multiple packages found for: {}".format(spec))
+            raise AssertionError(
+                f"Must have exactly one package of '{spec}' in "
+                f"default channels, found '{number_of_defaults}'. Aborting."
+            )
         return result
 
     def create_env(self):
@@ -1242,6 +1246,7 @@ class ZwikEnvironment(object):
                 else:
                     raise AssertionError("Package not found: {}".format(spec))
             if self._multiple_packages_found(result):
+                log.warning("Multiple packages found for '%s'." % spec)
                 result = self._filter_package_from_default_channels(result, spec)
             link_precs.append(result[0])
 

--- a/scripts/zwik_client.py
+++ b/scripts/zwik_client.py
@@ -1246,7 +1246,7 @@ class ZwikEnvironment(object):
                 else:
                     raise AssertionError("Package not found: {}".format(spec))
             if self._multiple_packages_found(result):
-                log.warning("Multiple packages found for '%s'." % spec)
+                log.warning("Multiple packages found for '%s'.", spec)
                 result = self._filter_package_from_default_channels(result, spec)
             link_precs.append(result[0])
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1172,8 +1172,6 @@ class TestZwikEnvironment(DummyServerEnvironmentTest):
 
 class TestZwikMultiplePackages(TestCase):
     def test_prefer_default_channels_when_multiple_packages(self):
-        settings = ZwikSettings()
-        env = ZwikEnvironment(zwik_settings=settings)
         spec = "my-package=0.0.0=py_0"
         default_channels = [
             "https://user:token@zwik.dev.bosch.com/packages/bios",
@@ -1188,13 +1186,13 @@ class TestZwikMultiplePackages(TestCase):
         result = (
             FakePackageRecord(schannel="bios"),
             FakePackageRecord(
-                schannel="https://some.server.com/conda/custom-channel"  # noqa
+                schannel="https://some.server.com/conda/custom-channel"
             ),
         )
 
         try:
-            env._filter_package_from_default_channels(
+            ZwikEnvironment._filter_package_from_default_channels(
                 result=result, default_channels=default_channels, spec=spec
             )
         except AssertionError:
-            self.fail("Should not have raise AssertionError.")
+            self.fail("Should not have raised AssertionError.")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1191,8 +1191,10 @@ class TestZwikMultiplePackages(TestCase):
         )
 
         try:
-            ZwikEnvironment._filter_package_from_default_channels(
+            result = ZwikEnvironment._filter_package_from_default_channels(
                 result=result, default_channels=default_channels, spec=spec
             )
         except AssertionError:
             self.fail("Should not have raised AssertionError.")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].schannel, "bios")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1191,3 +1191,21 @@ class TestZwikMultiplePackages(TestCase):
             self.fail("Should not have raised AssertionError.")
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].channel.base_url, default_channel_url)
+
+    def test_multiple_packages_found_but_no_packages_from_default_channels(self):
+        env = ZwikEnvironment(zwik_settings=ZwikSettings())
+        spec = "my-package=0.0.0=py_0"
+        package_record_custom_1 = mock.Mock()
+        package_record_custom_1.channel.base_url = (
+            "https://some.server.com/conda/custom-channel-1"
+        )
+        package_record_custom_2 = mock.Mock()
+        package_record_custom_2.channel.base_url = (
+            "https://some.server.com/conda/custom-channel-2"
+        )
+        result = (package_record_custom_1, package_record_custom_2)
+
+        with self.assertRaises(AssertionError):
+            result = env._filter_package_from_default_channels(result=result, spec=spec)
+
+        self.assertEqual(len(result), 2)


### PR DESCRIPTION
Zwik client does not properly prefer default channels when the same package spec exists in multiple channels.
This fixes it.