### PR TITLE
Allow setting of CONDA_PKGS_DIRS environment variable

### DIFF
--- a/scripts/zwik_client.py
+++ b/scripts/zwik_client.py
@@ -1543,8 +1543,6 @@ class ZwikEnvironment(object):
             "report_errors": False,
         }
 
-        os.environ["CONDA_PKGS_DIRS"] = pkgs_dir
-
         with TemporaryDirectory(prefix="zwik_tmp_") as tmpdir:
             rc_file = os.path.join(tmpdir, ".condarc")
             with open(rc_file, "w") as fp:


### PR DESCRIPTION
this is being overriden, which doesnt really make sense. If someone sets this env variable it should be used.